### PR TITLE
feat: add addVirtualCdRomSpec for attaching an empty CD-ROM device

### DIFF
--- a/src/Data/SoapData.php
+++ b/src/Data/SoapData.php
@@ -261,6 +261,23 @@ class SoapData
         ]);
     }
 
+    public function addVirtualCdRomSpec(int $controllerKey, int $unitNumber): VirtualCdrom
+    {
+        return new VirtualCdrom([
+            'key' => -1,
+            'backing' => new VirtualCdromRemoteAtapiBackingInfo([
+                'deviceName' => 'CDRom',
+            ]),
+            'connectable' => new VirtualDeviceConnectInfo([
+                'startConnected' => false,
+                'allowGuestControl' => true,
+                'connected' => false,
+            ]),
+            'controllerKey' => $controllerKey,
+            'unitNumber' => $unitNumber,
+        ]);
+    }
+
     public function unmountVirtualCdRomSpec(int $key, int $controllerKey): VirtualCdrom
     {
         return new VirtualCdrom([


### PR DESCRIPTION
Adds `SoapData::addVirtualCdRomSpec(int $controllerKey, int $unitNumber)` — builds a `VirtualCdrom` spec (key -1, remote-ATAPI backing, disconnected) for `operation: add` device changes.

Needed by vdc-backend's unattended ISO install mode (Packer `xelon-iso` builder support): the device create flow attaches a second, empty CD-ROM drive so auto-install media (OEMDRV Kickstart CD) can be mounted on it.

After merge, please tag **0.3.14** so vdc-backend can bump its composer pin.