### PR TITLE
chore: allow laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.0|^8.1|^8.2|^8.3",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "guzzlehttp/guzzle": "^7.0.1",
         "ext-soap": "*"
     },


### PR DESCRIPTION
Widens `illuminate/contracts` to add `|^13.0` so this package can be installed alongside Laravel 13.

Purely additive — all previously supported versions still resolve.

Needed to unblock the Laravel 13 upgrade in vdc-backend. Note that vdc-backend pins this package to the exact version `0.3.14`, so a new tag (`0.3.15`) will be required after merge before it can consume the change.