### PR TITLE
ci: recover missing tests and fix broken CI

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.5.1
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -8,14 +8,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@1.0.0
+        uses: aglipanci/laravel-pint-action@2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Fix styling

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -11,7 +11,7 @@ jobs:
     name: phpstan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -20,7 +20,7 @@ jobs:
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@4.0.0
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
             testbench: '8.*'
             php: '8.2'
           - laravel: '11.*'
-            testbench: '9.*'
+            testbench: '^9.5'
             php: '8.2'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,21 +10,27 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1]
-        laravel: [9.*]
+        laravel: ['9.*', '10.*', '11.*']
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
+          - laravel: '9.*'
+            testbench: '7.*'
+            php: '8.1'
+          - laravel: '10.*'
+            testbench: '8.*'
+            php: '8.2'
+          - laravel: '11.*'
+            testbench: '9.*'
+            php: '8.2'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: main
 
@@ -21,7 +21,7 @@ jobs:
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           branch: main
           commit_message: Update CHANGELOG

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "larastan/larastan": "^2.9",
         "nunomaduro/collision": "^6.1|^7.10|^8.1",
-        "orchestra/testbench": "^7.23|^8.1|^9.0",
+        "orchestra/testbench": "^7.23|^8.1|^9.5",
         "pestphp/pest": "^1.21|^2.34",
         "pestphp/pest-plugin-laravel": "^1.1|^2.4",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,15 @@
         "ext-soap": "*"
     },
     "require-dev": {
-        "nunomaduro/collision": "^6.1",
-        "pestphp/pest": "^1.21",
-        "pestphp/pest-plugin-laravel": "^1.1",
+        "larastan/larastan": "^2.9",
+        "nunomaduro/collision": "^6.1|^7.10|^8.1",
+        "orchestra/testbench": "^7.23|^8.1|^9.0",
+        "pestphp/pest": "^1.21|^2.34",
+        "pestphp/pest-plugin-laravel": "^1.1|^2.4",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5|^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,31 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Argument of an invalid type Xelon\\\\VmWareClient\\\\Types\\\\Core\\\\DynamicData supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Types/Core/DynamicData.php
+
+		-
+			message: "#^Dead catch \\- GuzzleHttp\\\\Exception\\\\ClientException is already caught above\\.$#"
+			count: 5
+			path: src/VcenterClient.php
+
+		-
+			message: "#^Access to an undefined property Exception\\:\\:\\$detail\\.$#"
+			count: 2
+			path: src/VcenterSoapClient.php
+
+		-
+			message: "#^Access to an undefined property Xelon\\\\VmWareClient\\\\VcenterSoapClient\\:\\:\\$version\\.$#"
+			count: 11
+			path: src/VcenterSoapClient.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 6
+			path: src/VcenterSoapClient.php
+
+		-
+			message: "#^Variable \\$result might not be defined\\.$#"
+			count: 2
+			path: src/VcenterSoapClient.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,9 +6,7 @@ parameters:
     paths:
         - src
         - config
-        - database
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/src/Traits/Soap/SoapGuestApis.php
+++ b/src/Traits/Soap/SoapGuestApis.php
@@ -20,7 +20,7 @@ trait SoapGuestApis
         ?string $localFilePath,
         string $guestFilePath,
         array $params = [],
-        string $data = null
+        ?string $data = null
     ): void {
         if ($localFilePath) {
             $fullScriptPath = base_path($localFilePath);

--- a/src/Traits/Soap/SoapImportApis.php
+++ b/src/Traits/Soap/SoapImportApis.php
@@ -36,7 +36,7 @@ trait SoapImportApis
         return $this->request('ParseDescriptor', $body);
     }
 
-    public function createImportSpec(string $ovfPath, string $resourcepool, string $datastore, array $networkMapping = null)
+    public function createImportSpec(string $ovfPath, string $resourcepool, string $datastore, ?array $networkMapping = null)
     {
         $body = [
             '_this' => [

--- a/src/Traits/Soap/SoapVmApis.php
+++ b/src/Traits/Soap/SoapVmApis.php
@@ -502,7 +502,7 @@ trait SoapVmApis
         string $name,
         array $vmIds,
         bool $isAntiAffinity = false,
-        int $key = null // unique rule key (remote_rule_id)
+        ?int $key = null // unique rule key (remote_rule_id)
     ) {
         $vm = [];
 

--- a/tests/Feature/Facades/VmWareClientFacadeTest.php
+++ b/tests/Feature/Facades/VmWareClientFacadeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Config;
+use Xelon\VmWareClient\Facades\VmWareClient;
+use Xelon\VmWareClient\VcenterClient;
+
+test('vmware client facade resolves to the correct instance', function () {
+    Config::set('vmware-php-client.vcenter_ip', 'https://vcenter.example.com');
+    Config::set('vmware-php-client.vcenter_login', 'admin');
+    Config::set('vmware-php-client.vcenter_password', 'password');
+    Config::set('vmware-php-client.vcenter_mode', 'rest');
+    Config::set('vmware-php-client.vcenter_version', 7.0);
+    
+    // Replace the bound instance with a mock to avoid actual connections
+    $this->app->bind('vmware-php-client', function ($app) {
+        $mockClient = Mockery::mock(VcenterClient::class);
+        
+        // Add any stub methods the facade might call
+        $mockClient->shouldReceive('getVms')
+            ->andReturn([]);
+            
+        return $mockClient;
+    });
+    
+    // Test the facade resolves correctly
+    expect(VmWareClient::getFacadeRoot())->toBeInstanceOf(VcenterClient::class);
+    
+    // Test a method call through the facade
+    $vms = VmWareClient::getVms();
+    expect($vms)->toBeArray();
+});

--- a/tests/Feature/Rest/VmApisTest.php
+++ b/tests/Feature/Rest/VmApisTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\Cache;
+use Xelon\VmWareClient\VcenterClient;
+use Xelon\VmWareClient\VmWareClientInit;
+
+test('getVms returns list of virtual machines', function () {
+    // Skip test that requires more complex mocking
+    $this->markTestSkipped('This test requires more advanced mocking techniques');
+});
+
+test('powerOnVm successfully powers on a VM', function () {
+    // Skip test that requires more complex mocking
+    $this->markTestSkipped('This test requires more advanced mocking techniques');
+});
+
+// Simple test for endpoint paths
+test('VM Rest API endpoints are constructed correctly', function () {
+    // Test the endpoint formatting directly
+    $client = new class('https://vcenter.example.com', 'admin', 'password', VmWareClientInit::MODE_REST) extends VcenterClient {
+        // Make methods public for testing
+        public function getPowerEndpoint(string $vmId): string {
+            return $this->apiUrlPrefix . '/vcenter/vm/' . $vmId . '/power/start';
+        }
+        
+        // Override to avoid actual REST calls
+        protected function initRestSession(): void {
+            $this->guzzleClient = new Client(['verify' => false, 'base_uri' => $this->ip]);
+        }
+    };
+    
+    // Test the endpoint format
+    $endpoint = $client->getPowerEndpoint('vm-123');
+    expect($endpoint)->toBe('/api/vcenter/vm/vm-123/power/start');
+});

--- a/tests/Feature/Soap/SoapVmApisTest.php
+++ b/tests/Feature/Soap/SoapVmApisTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use Xelon\VmWareClient\VcenterClient;
+use Xelon\VmWareClient\VcenterSoapClient;
+use Xelon\VmWareClient\VmWareClientInit;
+
+test('soap client can get vm by name', function () {
+    $this->markTestSkipped('Skipping test that requires SOAP connection');
+    
+    // This test would need more complex mocking to avoid actual SOAP connections
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+uses(
+    Xelon\VmWareClient\Tests\TestCase::class,
+)->in('Feature', 'Unit');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+function something()
+{
+    // ..
+}
+
+// Include Pest helper functions
+require_once __DIR__ . '/Pest/Helpers.php';

--- a/tests/Pest/Helpers.php
+++ b/tests/Pest/Helpers.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Xelon\VmWareClient\Tests\Pest;
+
+use Illuminate\Support\Arr;
+use Mockery;
+
+/**
+ * Create a mock response with the given data.
+ */
+function mockResponseData(array $data = [])
+{
+    $responseBody = json_encode(Arr::wrap($data));
+    
+    $responseMock = Mockery::mock('Psr\Http\Message\ResponseInterface');
+    $responseMock->shouldReceive('getBody')
+        ->andReturn($responseBody);
+        
+    return $responseMock;
+}
+
+/**
+ * Create a mock client that expects a specific request and returns the given response.
+ */
+function mockGuzzleClient($expectedMethod, $expectedUri, $responseData = [])
+{
+    $clientMock = Mockery::mock('GuzzleHttp\Client');
+    
+    $clientMock->shouldReceive($expectedMethod)
+        ->with($expectedUri, Mockery::any())
+        ->andReturn(mockResponseData($responseData));
+        
+    return $clientMock;
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Xelon\VmWareClient\Tests;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Orchestra\Testbench\TestCase as Orchestra;
+use Xelon\VmWareClient\VmWareClientServiceProvider;
+
+class TestCase extends Orchestra
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            VmWareClientServiceProvider::class,
+        ];
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        // Set up environment configuration for testing
+        $app['config']->set('vmware-php-client.session_ttl', 30);
+    }
+}

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -1,0 +1,13 @@
+<?php
+
+test('config has required values', function () {
+    // Ensure the config file contains all required keys
+    $config = config('vmware-php-client');
+    
+    expect($config)->toBeArray()
+        ->toHaveKey('session_ttl')
+        ->toHaveKey('enable_logs');
+    
+    // Test default session_ttl value
+    expect($config['session_ttl'])->toBeInt();
+});

--- a/tests/Unit/VcenterClientTest.php
+++ b/tests/Unit/VcenterClientTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use Xelon\VmWareClient\VcenterClient;
+use Xelon\VmWareClient\VcenterSoapClient;
+use Xelon\VmWareClient\VmWareClientInit;
+
+test('vcenter client can be instantiated in REST mode', function () {
+    // Create a testable mock to avoid actual API calls
+    $clientMock = new class('https://vcenter.example.com', 'admin', 'password', VmWareClientInit::MODE_REST) extends VcenterClient {
+        // Override to avoid actual REST calls
+        protected function initRestSession(): void {
+            $this->guzzleClient = new \GuzzleHttp\Client(['verify' => false, 'base_uri' => $this->ip]);
+        }
+    };
+    
+    expect($clientMock)->toBeInstanceOf(VcenterClient::class);
+    expect($clientMock->apiUrlPrefix)->toBe('/api');
+});
+
+test('vcenter client can be instantiated with version 6.7', function () {
+    // Create a testable mock to avoid actual API calls
+    $clientMock = new class('https://vcenter.example.com', 'admin', 'password', VmWareClientInit::MODE_REST, 6.7) extends VcenterClient {
+        // Override to avoid actual REST calls
+        protected function initRestSession(): void {
+            $this->guzzleClient = new \GuzzleHttp\Client(['verify' => false, 'base_uri' => $this->ip]);
+        }
+    };
+    
+    expect($clientMock)->toBeInstanceOf(VcenterClient::class);
+    expect($clientMock->apiUrlPrefix)->toBe('/rest');
+});
+
+test('vcenter client initializes soap client in both mode', function () {
+    $this->markTestSkipped('Skipping test that requires SOAP connection');
+});

--- a/tests/Unit/VmWareClientInitTest.php
+++ b/tests/Unit/VmWareClientInitTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use GuzzleHttp\Client;
+use Illuminate\Support\Facades\Cache;
+use Xelon\VmWareClient\VmWareClientInit;
+
+test('client can be instantiated in REST mode', function () {
+    // Skip entire test for now due to mocking complexities
+    $this->markTestSkipped('Requires more complex mocking');
+    
+    // This test would need more sophisticated mocking to pass
+});
+
+test('client can be instantiated in SOAP mode', function () {
+    $this->markTestSkipped('Skipping test that requires SOAP connection');
+});
+
+test('client throws exception on invalid mode', function () {
+    expect(fn() => new VmWareClientInit(
+        'https://vcenter.example.com',
+        'admin',
+        'password',
+        'invalid_mode'
+    ))->toThrow(\Exception::class, 'Illegal mode type');
+});


### PR DESCRIPTION
main had no tests/ directory at all, despite composer.json already wiring up Pest (autoload-dev, pestphp/pest require-dev, phpunit.xml.dist testsuite pointing at tests). Every run-tests CI run has failed with "Test directory tests not found" since the workflow was added. PHPStan CI has also been failing since introduction: phpstan.neon.dist referenced Larastan-only options (checkOctaneCompatibility, checkModelProperties) without larastan actually being a dependency, and a database path that doesn't exist in this repo.

Found an abandoned branch (origin/feat/phpstan, Apr 2025) with a real Pest test suite that was never merged, plus phpstan cleanup. Recovered from there and reconciled against current main:

- Restored tests/ (6 passing, 6 intentionally skipped — SOAP connection / advanced mocking not implemented)
- Added orchestra/testbench (needed by TestCase, was missing from composer.json)
- Added larastan/larastan and fixed phpstan.neon.dist (dropped dead `database` path, replaced deprecated checkMissingIterableValueType)
- Widened pest/pest-plugin-laravel/testbench/phpunit/collision dev constraints so Laravel 9-11 all still resolve (pestphp/pest-plugin-laravel and larastan don't have a version spanning 9 through 13 in one range — going further to 12/13 pulls in phpstan 2.x/larastan 3.x, which surfaces ~800 new (mostly real but unreviewed) findings in this package's SOAP transform code; left that out of scope here)
- Fixed 3 real PHP 8.4 implicit-nullable-parameter deprecations in the SOAP traits
- Generated phpstan-baseline.neon (27 pre-existing findings — dead catches, an undefined-property access, an always-true ternary, a possibly-undefined variable, a non-iterable foreach — tracked explicitly rather than fixed blind, since I don't have domain context on this SOAP client's intended behavior)
- Bumped every pinned/deprecated GitHub Action across all 5 workflows (actions/checkout v3->v5, ramsey/composer-install v2->v4, dependabot/fetch-metadata v1.5.1->v3, laravel-pint-action 1.0.0->2.6, git-auto-commit-action v4->v7, changelog-updater-action pinned to floating v1)
- run-tests.yml: fail-fast true->false (was masking failures across the matrix), Laravel matrix now 9/10/11 (was only 9) matched to the right testbench+php per version

Verified locally (PHP 8.4): tests pass, phpstan clean against baseline, and Laravel 9 (prefer-lowest) / 10 / 11 (prefer-stable) all resolve and pass. Laravel 12/13 CI coverage remains a known gap — tracked but not pursued here.